### PR TITLE
fix OpenAPI tags

### DIFF
--- a/core/api/controller/__init__.py
+++ b/core/api/controller/__init__.py
@@ -19,12 +19,12 @@ def create_app() -> FastAPI:
     )
 
     # routing
-    app.include_router(judge_controller.router, prefix='/judge', tags=['判定API'])
-    app.include_router(eval_controller.router, prefix='/eval', tags=['評価API'])
-    app.include_router(reading_controller.router, prefix='/reading', tags=['読み変換API'])
+    app.include_router(judge_controller.router, prefix='/judge', tags=['dajare'])
+    app.include_router(eval_controller.router, prefix='/eval', tags=['dajare'])
+    app.include_router(reading_controller.router, prefix='/reading', tags=['dajare'])
 
     # index
-    @app.get('/', tags=['index'])
+    @app.get('/')
     def index():
         return 'Hello, World!'
 
@@ -32,5 +32,9 @@ def create_app() -> FastAPI:
     app.title = 'DaaS API'
     app.description = 'This is a document of DaaS.'
     app.version = '1.0.0'
+
+    app.openapi_tags = [
+        {"name": "dajare", "description": "Operation with dajare _(ダジャレ)_ ."}
+    ]
 
     return app


### PR DESCRIPTION
## やったこと

- タグの名前を適切なものに変更
- タグの説明を追加

## その理由

[OpenAPI におけるタグ (tag) は操作の論理的なグループ分けをするもの](https://swagger.io/specification/#:~:text=tags%20can%20be%20used%20for%20logical%20grouping%20of%20operations%20by%20resources%20or%20any%20other%20qualifier.) で、操作の説明ではない。

また、https://github.com/OpenAPITools/openapi-generator は、タグによって API を操作するクラスを作成し、マルチバイト文字を無視すると思われる。そのため、タグの名前を`判定API` や `評価API` などのように設定すると、クラスの名前が `APIApi` という名前になって気持ち悪い。

